### PR TITLE
Be forwards-compatible with MongoDB 2.6.5

### DIFF
--- a/admin/admin.coffee
+++ b/admin/admin.coffee
@@ -238,8 +238,6 @@ Meteor.methods
       # (see mturk/test/test.js)
       if hitData.HITId
         HITs.update {HITId: HITId}, $set: hitData
-      else
-        HITs.remove {HITId: HITId}
     catch e
       throw new Meteor.Error(500, e.toString())
 

--- a/admin/admin.coffee
+++ b/admin/admin.coffee
@@ -234,7 +234,12 @@ Meteor.methods
     throw new Meteor.Error(400, "HIT ID not specified") unless HITId
     try
       hitData = TurkServer.mturk "GetHIT", HITId: HITId
-      HITs.update {HITId: HITId}, $set: hitData
+      # might be better to reuse mturk's validateHIT
+      # (see mturk/test/test.js)
+      if hitData.HITId
+        HITs.update {HITId: HITId}, $set: hitData
+      else
+        HITs.remove {HITId: HITId}
     catch e
       throw new Meteor.Error(500, e.toString())
 

--- a/lib/batches.coffee
+++ b/lib/batches.coffee
@@ -45,10 +45,8 @@ class TurkServer.Batch
 
 TurkServer.ensureBatchExists = (props) ->
   throw new Error("Batch must have a name") unless props.name?
-  Batches.upsert {name: props.name},
-    $set: _.omit(props, "name")
+  Batches.upsert {name: props.name}, props
 
 TurkServer.ensureTreatmentExists = (props) ->
   throw new Error("Treatment must have a name") unless props.name?
-  Treatments.upsert {name: props.name},
-    $set: _.omit(props, "name")
+  Treatments.upsert {name: props.name}, props

--- a/lib/turkserver.coffee
+++ b/lib/turkserver.coffee
@@ -209,7 +209,7 @@ Meteor.startup ->
   console.log "#{prefix} #{hitTypeBatchUpdates} HIT Types updated with batch Ids" if hitTypeBatchUpdates > 0
 
   experimentBatchUpdates = 0
-  Experiments.find({batchId: $exists: false, startTime: $exists: true}).forEach (exp, idx) ->
+  Experiments.find({batchId: {$exists: false}, startTime: {$exists: true}}).forEach (exp, idx) ->
     experimentBatchUpdates = idx + 1
     someAsst = Assignments.findOne
       "instances.id": exp._id

--- a/tests/admin_tests.coffee
+++ b/tests/admin_tests.coffee
@@ -2,7 +2,8 @@ batchId = "mturkBatch"
 hitTypeId = "mturkHITType"
 
 # Create dummy batch and HIT Type
-Batches.upsert batchId, $set: {}
+Batches.remove batchId
+Batches.insert _id: batchId
 
 HITTypes.upsert {HITTypeId: hitTypeId},
   $set: { batchId }

--- a/tests/connection_tests.coffee
+++ b/tests/connection_tests.coffee
@@ -1,7 +1,7 @@
 batchId = "connectionBatch"
 
-Batches.upsert batchId,
-  $set: {}
+Batches.remove batchId
+Batches.insert _id: batchId
 
 batch = TurkServer.Batch.getBatch(batchId)
 

--- a/tests/experiment_tests.coffee
+++ b/tests/experiment_tests.coffee
@@ -25,7 +25,9 @@ TurkServer.onIdle -> idleContext = this
 TurkServer.onActive -> activeContext = this
 
 # Ensure batch exists
-Batches.upsert "expBatch", $set: {}
+batchId = "expBatch"
+Batches.remove batchId
+Batches.insert _id: batchId
 
 # Set up a treatment for testing
 TurkServer.ensureTreatmentExists

--- a/tests/lobby_tests.coffee
+++ b/tests/lobby_tests.coffee
@@ -1,7 +1,8 @@
 if Meteor.isServer
   # Create a batch to test the lobby on
   batchId = "lobbyBatchTest"
-  Batches.upsert batchId, $set: {}
+  Batches.remove batchId
+  Batches.insert _id: batchId
 
   lobby = TurkServer.Batch.getBatch(batchId).lobby
 


### PR DESCRIPTION
This is probably not a pressing need, but I noticed that the code breaks against MongoDB 2.6.5. Eventually Meteor will upgrade the embedded MongoDB and client code, so it probably wouldn't hurt to be forwards-compatible if it isn't too much effort. MongoDB 2.6.5 is more strict that 2.4.x, so it offers a bit more safety. For example, see the bug I found/fixed in 32492039e693026f11c553825d557faaf6ee2fd2 thanks to stricter checking in MongoDB 2.6.5.

Here's an example error one will encounter running `meteor test-packages ./` when `MONGO_URL` points to a local MongoDB 2.6.5 instance:

    W20141023-10:28:53.231(-7)? (STDERR) 
    W20141023-10:28:53.232(-7)? (STDERR) /home/user/.meteor/packages/meteor-tool/.1.0.34.oxpz2l++os.linux.x86_64+web.browser+web.cordova/meteor-tool-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/future.js:206
    W20141023-10:28:53.232(-7)? (STDERR) 						throw(ex);
    W20141023-10:28:53.232(-7)? (STDERR) 						      ^
    W20141023-10:28:53.287(-7)? (STDERR) MongoError: '$set' is empty. You must specify a field like so: {$mod: {<field>: ...}}
    W20141023-10:28:53.287(-7)? (STDERR)     at Object.Future.wait (/home/user/.meteor/packages/meteor-tool/.1.0.34.oxpz2l++os.linux.x86_64+web.browser+web.cordova/meteor-tool-os.linux.x86_64/dev_bundle/lib/node_modules/fibers/future.js:326:15)
    W20141023-10:28:53.287(-7)? (STDERR)     at null.<anonymous> (packages/meteor/helpers.js:118)
    W20141023-10:28:53.287(-7)? (STDERR)     at MongoConnection.(anonymous function) [as update] (packages/mongo/mongo_driver.js:607)
    W20141023-10:28:53.288(-7)? (STDERR)     at Object.fields (packages/matb33:collection-hooks/update.js:71)
    W20141023-10:28:53.288(-7)? (STDERR)     at Object.collection.(anonymous function) [as update] (packages/matb33:collection-hooks/collection-hooks.js:104)
    W20141023-10:28:53.288(-7)? (STDERR)     at Mongo.Collection.(anonymous function) [as update] (packages/mongo/collection.js:572)
    W20141023-10:28:53.288(-7)? (STDERR)     at Mongo.Collection.upsert (packages/mongo/collection.js:606)
    W20141023-10:28:53.288(-7)? (STDERR)     at __coffeescriptShare (packages/local-test:mizzao:turkserver/tests/lobby_tests.coffee:4:10)
    W20141023-10:28:53.288(-7)? (STDERR)     at /tmp/meteor-test-run1k3mm8q/.meteor/local/build/programs/server/packages/local-test_mizzao_turkserver.js:305:4
    W20141023-10:28:53.289(-7)? (STDERR)     at /tmp/meteor-test-run1k3mm8q/.meteor/local/build/programs/server/packages/local-test_mizzao_turkserver.js:2931:3
    W20141023-10:28:53.289(-7)? (STDERR)     - - - - -
    W20141023-10:28:53.289(-7)? (STDERR)     at Object.toError (/home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/utils.js:110:11)
    W20141023-10:28:53.289(-7)? (STDERR)     at /home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/collection/core.js:542:27
    W20141023-10:28:53.289(-7)? (STDERR)     at /home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/db.js:1129:7
    W20141023-10:28:53.289(-7)? (STDERR)     at /home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/db.js:1843:9
    W20141023-10:28:53.289(-7)? (STDERR)     at Server.Base._callHandler (/home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/connection/base.js:445:41)
    W20141023-10:28:53.289(-7)? (STDERR)     at /home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/connection/server.js:468:18
    W20141023-10:28:53.289(-7)? (STDERR)     at MongoReply.parseBody (/home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/responses/mongo_reply.js:68:5)
    W20141023-10:28:53.289(-7)? (STDERR)     at null.<anonymous> (/home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/connection/server.js:426:20)
    W20141023-10:28:53.289(-7)? (STDERR)     at emit (events.js:95:17)
    W20141023-10:28:53.290(-7)? (STDERR)     at null.<anonymous> (/home/user/.meteor/packages/mongo/.1.0.7.vij4hh++os+web.browser+web.cordova/npm/node_modules/mongodb/lib/mongodb/connection/connection_pool.js:201:13)

All tests pass. But we'll let TravisCI say for sure. :)